### PR TITLE
Remove Docker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A Customed Operating System for Security Researchers and Penetration Testers. Ba
 
 
 ### Plague Security Editions
-[Plague Security Docker Edition](https://github.com/plaguesec/plaguesec-docker)  
 [Plague Security Live Build ISO](https://github.com/plaguesec/plaguesec-os)  
 Plague Security Raspberry PI Editon (Soon)  
 Plague Security Tablet (Soon)  


### PR DESCRIPTION
Docker Variant of PlagueSecurity OS will be Deprecated and it will no longer Support for the Next Update